### PR TITLE
update struct packing to use #pragma pack() syntax

### DIFF
--- a/api/yacp_api.h
+++ b/api/yacp_api.h
@@ -45,11 +45,15 @@ typedef union cal_value
 } cal_value;
 
 // Each override has a status (OVERRIDDEN, PASSTHROUGH), and a value.
-typedef struct __attribute__((packed)) cal_override
+
+#pragma pack(push)
+#pragma pack(1)
+typedef struct cal_override
 {
   uint8_t status;
   cal_value value;
 } cal_override;
+#pragma pack(pop)
 
 // Driver Functions
 

--- a/apps/YACPGen/YACPGen.py
+++ b/apps/YACPGen/YACPGen.py
@@ -48,7 +48,9 @@ def header_start(rev):
     hfile.write("#define CAL_REVISION "+rev+"\n\n")
 
 def measurements_start():
-    hfile.write("typedef struct __attribute__((packed)) cal_measurements\n")
+    hfile.write("#pragma pack(push)\n")
+    hfile.write("#pragma pack(1)\n")
+    hfile.write("typedef struct cal_measurements\n")
     hfile.write("{\n")
 
 def measurements_var(name,cal_type,unit):
@@ -61,7 +63,8 @@ def measurements_end():
     
 
 def settings_start():
-    hfile.write("typedef struct __attribute__((packed)) cal_settings\n")
+    hfile.write("#pragma pack(1)\n")
+    hfile.write("typedef struct cal_settings\n")
     hfile.write("{\n")
 
 def settings_var(name,cal_type,unit):
@@ -74,7 +77,8 @@ def settings_end():
     
 
 def override_start():
-    hfile.write("typedef struct __attribute__((packed)) cal_overrides\n")
+    hfile.write("#pragma pack(1)\n")
+    hfile.write("typedef struct cal_overrides\n")
     hfile.write("{\n")
 
 def override_var(name,unit):
@@ -83,7 +87,8 @@ def override_var(name,unit):
     hfile.write("\tcal_override "+name+";"+unit+"\n")
 
 def override_end():
-    hfile.write("} cal_overrides;\n\n")
+    hfile.write("} cal_overrides;\n")
+    hfile.write("#pragma pack(pop)\n\n")
     
 
 def header_end():


### PR DESCRIPTION
see https://gcc.gnu.org/onlinedocs/gcc/extensions-to-the-c-language-family/pragmas-accepted-by-gcc.html#structure-layout-pragmas. 

This change will allow for `cal.h/yacp_cal.h` to compile using non-GCC C compilers.

